### PR TITLE
Adds missing  value to example toml. Adds instructions for mac

### DIFF
--- a/LibraryLoader.example.toml
+++ b/LibraryLoader.example.toml
@@ -1,5 +1,6 @@
 [settings]
 watch_path = "~/Downloads"
+recursive = false
 
 [formats.'3d']
 format = "3d"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,30 @@ You have to install rust via rustup and initialize it with rustup-init command.
 ./macos-compile.sh
 ```
 
+### Setup on macOS
+
+Edit the `LibraryLoader.example.toml` and fill in your login details for `componentsearchengine.com`. Rename the file to `LibraryLoader.toml` and place it in `~/Library/Application Support/LibraryLoader.toml`.
+
+e.g.
+
+```shell
+cp LibraryLoader.example.toml ~/Library/Application\ Support/LibraryLoader.toml"
+```
+
+### Running on macOS
+
+GUI:
+
+```shell
+cargo run --bin library-loader-gui
+```
+
+or CLI:
+
+```shell
+cargo run --bin library-loader-cli
+```
+
 ## What/Why?
 
 This is an implementation of [https://www.samacsys.com/library-loader/](https://www.samacsys.com/library-loader/) in Rust. Why? Well, since the library-loader SamacSys provides only works on Windows, I thought it would be neat to make something similar but available to everyone.


### PR DESCRIPTION
This adds some more detailed instructions for running on MacOs. I also noticed that the `recursive` option is missing from the example toml config file.